### PR TITLE
Fix wrong key for ArrayHelper to subordinate class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ﻿#CHANGELOG(Registro de alterações)
 
+###[0.0.3] - Fix wrong key for ArrayHelper to subordinate class ([@lucianolima00](https://gitlab.com/lucianolima00))
+
 ###[0.0.2] - Support to PHP 7.0 and above ([@thtmorais](https://gitlab.com/thtmorais))
 
 ###[0.0.1] - yii2-dropdown ([@thtmorais](https://gitlab.com/thtmorais))

--- a/src/views/dropdown.php
+++ b/src/views/dropdown.php
@@ -21,7 +21,7 @@ $dropdownMainText = ArrayHelper::getValue($dropdown->main,"text","main");
         <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
             <?php foreach ($dropdown->subordinate as $subordinateId => $subordinate) : ?>
                 <li>
-                    <a id="<?= ArrayHelper::getValue($subordinate,"id", $subordinateId) ?>" href="<?= ArrayHelper::getValue($subordinate,"href","#$subordinateId") ?>" class="<?= ArrayHelper::getValue($subordinate,"href","$subordinateId") ?>"><?= ArrayHelper::getValue($subordinate,"text", $subordinateId) ?></a>
+                    <a id="<?= ArrayHelper::getValue($subordinate,"id", $subordinateId) ?>" href="<?= ArrayHelper::getValue($subordinate,"href","#$subordinateId") ?>" class="<?= ArrayHelper::getValue($subordinate,"class","$subordinateId") ?>"><?= ArrayHelper::getValue($subordinate,"text", $subordinateId) ?></a>
                 </li>
             <?php endforeach; ?>
         </ul>


### PR DESCRIPTION
Wrong key for subordinate class on ArrayHelper, getting href instead